### PR TITLE
Add __len__ to BatchStatement

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -791,10 +791,13 @@ class BatchStatement(Statement):
         self._maybe_set_routing_attributes(statement)
         self._update_custom_payload(statement)
 
+    def __len__(self):
+        return len(self._statements_and_parameters)
+
     def __str__(self):
         consistency = ConsistencyLevel.value_to_name.get(self.consistency_level, 'Not Set')
         return (u'<BatchStatement type=%s, statements=%d, consistency=%s>' %
-                (self.batch_type, len(self._statements_and_parameters), consistency))
+                (self.batch_type, len(self), consistency))
     __repr__ = __str__
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -66,3 +66,10 @@ class BatchStatementTest(unittest.TestCase):
         bound_statements = [t[1] for t in batch._statements_and_parameters]
         str_parameters = [str(i) for i in range(10)]
         self.assertEqual(bound_statements, str_parameters)
+
+    def test_len(self):
+        for n in 0, 10, 100:
+            batch = BatchStatement()
+            batch.add_all(statements=['%s'] * n,
+                          parameters=[(i,) for i in range(n)])
+            self.assertEqual(len(batch), n)


### PR DESCRIPTION
A **len** method on BatchStatement would allow getting the length of the batch without poking around in the 'private' _statements_and_parameters field.
